### PR TITLE
Remove `recurse` for `homebrew_install_path` subdirs

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -70,7 +70,6 @@
     state: directory
     owner: "{{ homebrew_user }}"
     group: "{{ homebrew_group }}"
-    recurse: true
   become: true
 
 # Place brew binary in proper location and complete setup.


### PR DESCRIPTION
OSX 13+ ?